### PR TITLE
fix: secret creation on post-install hook

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.7
+version: 1.1.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/templates/init-migrate-hook.yaml
+++ b/templates/init-migrate-hook.yaml
@@ -6,7 +6,7 @@ metadata:
   name: {{ template "quorumkeymanager.fullname" . }}-hook-secretmap
   annotations:
     {{- include "quorumkeymanager.annotations" . | nindent 4 }}
-    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook": post-install
     "helm.sh/hook-weight": "5"
     "helm.sh/hook-delete-policy": hook-succeeded
   labels:


### PR DESCRIPTION
## PR Description

Right now, defining `.Values.migrate.environmentSecrets` is not working because of the hook event used for the secret creation and the job.

## Issue

Fix the issue https://github.com/ConsenSys/quorum-key-manager-helm/issues/33